### PR TITLE
move parts of sqlite bindings to a separate module Fixes #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build
 .gradle
 buildSrc/build
 sqlitebindings/build
+sqlitebindings-api/build
 jnigenerator/build
 #ignore core dump files
 sqlitebindings/core
@@ -10,3 +11,4 @@ sqlitebindings/hs_err_pid*
 ksqlite3/core
 ksqlite3/hs_err_pid*
 ksqlite3/build
+.DS_Store

--- a/jnigenerator/src/main/kotlin/com/birbit/jnigen/ClassNames.kt
+++ b/jnigenerator/src/main/kotlin/com/birbit/jnigen/ClassNames.kt
@@ -19,11 +19,13 @@ import com.squareup.kotlinpoet.ClassName
 
 private inline fun jniType(value: String) = ClassName("com.birbit.jni", value)
 private inline fun internalType(value: String) = ClassName("com.birbit.sqlite3.internal", value)
+private inline fun bindingApiType(value: String) = ClassName("com.birbit.sqlite3", value)
+
 private inline fun interopType(value: String) = ClassName("kotlinx.cinterop", value)
 
 object ClassNames {
     val JBYTEARRAY = jniType("jbyteArray")
-    val RESULT_CODE = internalType("ResultCode")
+    val RESULT_CODE = bindingApiType("ResultCode")
     val JINT = jniType("jint")
     val JLONG = jniType("jlong")
     val JDOUBLE = jniType("jdouble")
@@ -38,6 +40,6 @@ object ClassNames {
     val SQLITE_API = internalType("SqliteApi")
     val DB_REF = internalType("DbRef")
     val STMT_REF = internalType("StmtRef")
-    val AUTHORIZER = internalType("Authorizer")
-    val COLUMN_TYPE = internalType("ColumnType")
+    val AUTHORIZER = bindingApiType("Authorizer")
+    val COLUMN_TYPE = bindingApiType("ColumnType")
 }

--- a/ksqlite3/src/commonMain/kotlin/com/birbit/sqlite3/SqliteConnection.kt
+++ b/ksqlite3/src/commonMain/kotlin/com/birbit/sqlite3/SqliteConnection.kt
@@ -15,11 +15,7 @@
  */
 package com.birbit.sqlite3
 
-import com.birbit.sqlite3.internal.AuthResult
-import com.birbit.sqlite3.internal.AuthorizationParams
-import com.birbit.sqlite3.internal.Authorizer
 import com.birbit.sqlite3.internal.DbRef
-import com.birbit.sqlite3.internal.ResultCode
 import com.birbit.sqlite3.internal.SqliteApi
 
 class SqliteConnection private constructor(

--- a/ksqlite3/src/commonMain/kotlin/com/birbit/sqlite3/SqliteStmt.kt
+++ b/ksqlite3/src/commonMain/kotlin/com/birbit/sqlite3/SqliteStmt.kt
@@ -15,9 +15,7 @@
  */
 package com.birbit.sqlite3
 
-import com.birbit.sqlite3.internal.ResultCode
 import com.birbit.sqlite3.internal.SqliteApi
-import com.birbit.sqlite3.internal.SqliteException
 import com.birbit.sqlite3.internal.StmtRef
 
 class SqliteStmt(

--- a/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/SqliteConnectionTest.kt
+++ b/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/SqliteConnectionTest.kt
@@ -15,10 +15,6 @@
  */
 package com.birbit.sqlite3
 
-import com.birbit.sqlite3.internal.AuthResult
-import com.birbit.sqlite3.internal.AuthorizationParams
-import com.birbit.sqlite3.internal.ResultCode
-import com.birbit.sqlite3.internal.SqliteException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/StatementTest.kt
+++ b/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/StatementTest.kt
@@ -17,9 +17,6 @@ package com.birbit.sqlite3
 
 import com.birbit.sqlite3.SqliteStmt.Metadata
 import com.birbit.sqlite3.SqliteStmt.Metadata.ColumnInfo
-import com.birbit.sqlite3.internal.ColumnType
-import com.birbit.sqlite3.internal.ResultCode
-import com.birbit.sqlite3.internal.SqliteException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/sqlitebindings-api/README.md
+++ b/sqlitebindings-api/README.md
@@ -1,0 +1,4 @@
+Module to expose common SQLite related classes from the sqlitebindings artifact.
+
+This allows ksqlite to have an internal dependency on sqlitebindings while
+still exposing some parts as APIs (like ResultCode)

--- a/sqlitebindings-api/build.gradle.kts
+++ b/sqlitebindings-api/build.gradle.kts
@@ -30,31 +30,12 @@ repositories {
 kotlin {
     setupCommon(gradle) {
     }
+    jvm()
 
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
-                implementation(project(":sqlitebindings"))
-                api(project(":sqlitebindings-api"))
-            }
-        }
-        val commonTest by getting {
-            dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
-            }
-        }
-        // Default source set for JVM-specific sources and dependencies:
-        jvm().compilations["main"].defaultSourceSet {
-            dependencies {
-                implementation(kotlin("stdlib-jdk8"))
-            }
-        }
-        // JVM-specific tests and their dependencies:
-        jvm().compilations["test"].defaultSourceSet {
-            dependencies {
-                implementation(kotlin("test-junit"))
+                implementation(kotlin("stdlib"))
             }
         }
     }

--- a/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/AuthResult.kt
+++ b/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/AuthResult.kt
@@ -14,5 +14,12 @@
  * limitations under the License.
  */
 package com.birbit.sqlite3
-// TODO check if this is enough to make it public API from here
-typealias ResultCode = com.birbit.sqlite3.internal.ResultCode
+
+// see https://www.sqlite.org/c3ref/c_deny.html
+inline class AuthResult(val value: Int) {
+    companion object {
+        val OK = AuthResult(0)
+        val DENY = AuthResult(1)
+        val IGNORE = AuthResult(2)
+    }
+}

--- a/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/AuthorizationParams.kt
+++ b/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/AuthorizationParams.kt
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.birbit.sqlite3
 
-pluginManagement {
-    repositories {
-        maven("https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1793,branch:(default:any)/artifacts/content/maven")
-
-        mavenCentral()
-
-        maven("https://plugins.gradle.org/m2/")
+class AuthorizationParams(
+    val actionCode: Int,
+    val param1: String?,
+    val param2: String?,
+    val param3: String?,
+    val param4: String?
+) {
+    override fun toString(): String {
+        return "AuthorizationParams(actionCode=$actionCode, param1=$param1, param2=$param2, param3=$param3, " +
+            "param4=$param4)"
     }
 }
-include("sqlitebindings", "sqlitebindings-api", "jnigenerator", "ksqlite3")
-enableFeaturePreview("GRADLE_METADATA")
-

--- a/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/Authorizer.kt
+++ b/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/Authorizer.kt
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.birbit.sqlite3
 
-pluginManagement {
-    repositories {
-        maven("https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1793,branch:(default:any)/artifacts/content/maven")
-
-        mavenCentral()
-
-        maven("https://plugins.gradle.org/m2/")
+interface Authorizer {
+    operator fun invoke(params: AuthorizationParams): AuthResult
+    fun dispose() {
     }
 }
-include("sqlitebindings", "sqlitebindings-api", "jnigenerator", "ksqlite3")
-enableFeaturePreview("GRADLE_METADATA")
-

--- a/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/ColumnType.kt
+++ b/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/ColumnType.kt
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.birbit.sqlite3
 
-pluginManagement {
-    repositories {
-        maven("https://teamcity.jetbrains.com/guestAuth/app/rest/builds/buildType:(id:Kotlin_KotlinPublic_Compiler),number:1.4.0-dev-1793,branch:(default:any)/artifacts/content/maven")
-
-        mavenCentral()
-
-        maven("https://plugins.gradle.org/m2/")
+// see https://www.sqlite.org/c3ref/c_blob.html
+inline class ColumnType(val value: Int) {
+    companion object {
+        val INTEGER = ColumnType(1)
+        val FLOAT = ColumnType(2)
+        val STRING = ColumnType(3)
+        val BLOB = ColumnType(4)
+        val NULL = ColumnType(5)
     }
 }
-include("sqlitebindings", "sqlitebindings-api", "jnigenerator", "ksqlite3")
-enableFeaturePreview("GRADLE_METADATA")
-

--- a/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/ResultCode.kt
+++ b/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/ResultCode.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.birbit.sqlite3
+
+// commonized sqlite APIs to build the rest in common, or most at least
+inline class ResultCode(val value: Int) {
+    companion object {
+        val OK = ResultCode(0) /* Successful result */
+        val ERROR = ResultCode(1) /* Generic error */
+        val INTERNAL = ResultCode(2) /* Internal logic error in SQLite */
+        val PERM = ResultCode(3) /* Access permission denied */
+        val ABORT = ResultCode(4) /* Callback routine requested an abort */
+        val BUSY = ResultCode(5) /* The database file is locked */
+        val LOCKED = ResultCode(6) /* A table in the database is locked */
+        val NOMEM = ResultCode(7) /* A malloc() failed */
+        val READONLY = ResultCode(8) /* Attempt to write a readonly database */
+        val INTERRUPT =
+            ResultCode(9) /* Operation terminated by sqlite3_interrupt()*/
+        val IOERR = ResultCode(10) /* Some kind of disk I/O error occurred */
+        val CORRUPT = ResultCode(11) /* The database disk image is malformed */
+        val NOTFOUND =
+            ResultCode(12) /* Unknown opcode in sqlite3_file_control() */
+        val FULL = ResultCode(13) /* Insertion failed because database is full */
+        val CANTOPEN = ResultCode(14) /* Unable to open the database file */
+        val PROTOCOL = ResultCode(15) /* Database lock protocol error */
+        val EMPTY = ResultCode(16) /* Internal use only */
+        val SCHEMA = ResultCode(17) /* The database schema changed */
+        val TOOBIG = ResultCode(18) /* String or BLOB exceeds size limit */
+        val CONSTRAINT = ResultCode(19) /* Abort due to constraint violation */
+        val MISMATCH = ResultCode(20) /* Data type mismatch */
+        val MISUSE = ResultCode(21) /* Library used incorrectly */
+        val NOLFS = ResultCode(22) /* Uses OS features not supported on host */
+        val AUTH = ResultCode(23) /* Authorization denied */
+        val FORMAT = ResultCode(24) /* Not used */
+        val RANGE =
+            ResultCode(25) /* 2nd parameter to sqlite3_bind out of range */
+        val NOTADB = ResultCode(26) /* File opened that is not a database file */
+        val NOTICE = ResultCode(27) /* Notifications from sqlite3_log() */
+        val WARNING = ResultCode(28) /* Warnings from sqlite3_log() */
+        val ROW = ResultCode(100) /* sqlite3_step() has another row ready */
+        val DONE = ResultCode(101) /* sqlite3_step() has finished executing */
+    }
+}

--- a/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/SqliteException.kt
+++ b/sqlitebindings-api/src/commonMain/kotlin/com/birbit/sqlite3/SqliteException.kt
@@ -13,22 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.birbit.sqlite3.internal
+package com.birbit.sqlite3
 
 class SqliteException(
     val resultCode: ResultCode,
     val msg: String
 ) : Throwable(msg) {
-    companion object {
-        inline fun buildFromConnection(dbRef: DbRef, errorCode: Int?): SqliteException {
-            return SqliteException(
-                resultCode = errorCode?.let { ResultCode(it) } ?: SqliteApi.errorCode(dbRef),
-                msg = SqliteApi.errorMsg(dbRef) ?: errorCode?.let { SqliteApi.errorString(ResultCode(it)) }
-                ?: "unknown error"
-            )
-        }
-    }
-
     override fun toString(): String {
         return "[ResultCode: $resultCode] $msg"
     }
@@ -50,15 +40,6 @@ class SqliteException(
         result = 31 * result + msg.hashCode()
         return result
     }
-}
 
-// TODO trying to use ResultCode here crashed the compiler, hence using Ints
-internal inline fun checkResultCode(
-    dbRef: DbRef,
-    received: Int,
-    expected: Int
-) {
-    if (received != expected) {
-        throw SqliteException.buildFromConnection(dbRef, received)
-    }
+    companion object
 }

--- a/sqlitebindings/build.gradle.kts
+++ b/sqlitebindings/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
         binaries {
             sharedLib(namePrefix = "sqlite3jni")
         }
+        compilations["main"].defaultSourceSet {
+            dependencies {
+                project(":sqlitebindings-api")
+            }
+        }
         compilations["main"].cinterops.create("jni") {
             // JDK is required here, JRE is not enough
             val javaHome = File(System.getenv("JAVA_HOME") ?: System.getProperty("java.home"))
@@ -59,13 +64,15 @@ kotlin {
 
     val combinedSharedLibsFolder = project.buildDir.resolve("combinedSharedLibs")
     val combineSharedLibsTask =
-        com.birbit.ksqlite.build.CollectNativeLibrariesTask.create(project, "sqlite3jni", combinedSharedLibsFolder)
+        com.birbit.ksqlite.build.CollectNativeLibrariesTask
+            .create(project, "sqlite3jni", combinedSharedLibsFolder)
     jvm().compilations["main"].compileKotlinTask.dependsOn(combineSharedLibsTask)
 
     sourceSets {
         val commonMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-common"))
+                api(project(":sqlitebindings-api"))
             }
         }
         val commonTest by getting {

--- a/sqlitebindings/src/commonMain/kotlin/com/birbit/sqlite3/internal/SqliteApi.kt
+++ b/sqlitebindings/src/commonMain/kotlin/com/birbit/sqlite3/internal/SqliteApi.kt
@@ -15,62 +15,30 @@
  */
 package com.birbit.sqlite3.internal
 
-// see https://www.sqlite.org/c3ref/c_deny.html
-inline class AuthResult(val value: Int) {
-    companion object {
-        val OK = AuthResult(0)
-        val DENY = AuthResult(1)
-        val IGNORE = AuthResult(2)
-    }
-}
-// see https://www.sqlite.org/c3ref/c_blob.html
-inline class ColumnType(val value: Int) {
-    companion object {
-        val INTEGER = ColumnType(1)
-        val FLOAT = ColumnType(2)
-        val STRING = ColumnType(3)
-        val BLOB = ColumnType(4)
-        val NULL = ColumnType(5)
-    }
-}
-// commonized sqlite APIs to build the rest in common, or most at least
-inline class ResultCode(val value: Int) {
-    fun errorString() = SqliteApi.errorString(this)
+import com.birbit.sqlite3.Authorizer
+import com.birbit.sqlite3.ColumnType
+import com.birbit.sqlite3.ResultCode
+import com.birbit.sqlite3.SqliteException
 
-    companion object {
-        val OK = ResultCode(0) /* Successful result */
-        val ERROR = ResultCode(1) /* Generic error */
-        val INTERNAL = ResultCode(2) /* Internal logic error in SQLite */
-        val PERM = ResultCode(3) /* Access permission denied */
-        val ABORT = ResultCode(4) /* Callback routine requested an abort */
-        val BUSY = ResultCode(5) /* The database file is locked */
-        val LOCKED = ResultCode(6) /* A table in the database is locked */
-        val NOMEM = ResultCode(7) /* A malloc() failed */
-        val READONLY = ResultCode(8) /* Attempt to write a readonly database */
-        val INTERRUPT = ResultCode(9) /* Operation terminated by sqlite3_interrupt()*/
-        val IOERR = ResultCode(10) /* Some kind of disk I/O error occurred */
-        val CORRUPT = ResultCode(11) /* The database disk image is malformed */
-        val NOTFOUND = ResultCode(12) /* Unknown opcode in sqlite3_file_control() */
-        val FULL = ResultCode(13) /* Insertion failed because database is full */
-        val CANTOPEN = ResultCode(14) /* Unable to open the database file */
-        val PROTOCOL = ResultCode(15) /* Database lock protocol error */
-        val EMPTY = ResultCode(16) /* Internal use only */
-        val SCHEMA = ResultCode(17) /* The database schema changed */
-        val TOOBIG = ResultCode(18) /* String or BLOB exceeds size limit */
-        val CONSTRAINT = ResultCode(19) /* Abort due to constraint violation */
-        val MISMATCH = ResultCode(20) /* Data type mismatch */
-        val MISUSE = ResultCode(21) /* Library used incorrectly */
-        val NOLFS = ResultCode(22) /* Uses OS features not supported on host */
-        val AUTH = ResultCode(23) /* Authorization denied */
-        val FORMAT = ResultCode(24) /* Not used */
-        val RANGE = ResultCode(25) /* 2nd parameter to sqlite3_bind out of range */
-        val NOTADB = ResultCode(26) /* File opened that is not a database file */
-        val NOTICE = ResultCode(27) /* Notifications from sqlite3_log() */
-        val WARNING = ResultCode(28) /* Warnings from sqlite3_log() */
-        val ROW = ResultCode(100) /* sqlite3_step() has another row ready */
-        val DONE = ResultCode(101) /* sqlite3_step() has finished executing */
+// TODO trying to use ResultCode here crashed the compiler, hence using Ints
+internal inline fun checkResultCode(
+    dbRef: DbRef,
+    received: Int,
+    expected: Int
+) {
+    if (received != expected) {
+        throw SqliteException.buildFromConnection(dbRef, received)
     }
 }
+
+internal fun SqliteException.Companion.buildFromConnection(dbRef: DbRef, errorCode: Int?): SqliteException {
+    return SqliteException(
+        resultCode = errorCode?.let { ResultCode(it) } ?: SqliteApi.errorCode(dbRef),
+        msg = SqliteApi.errorMsg(dbRef) ?: errorCode?.let { SqliteApi.errorString(ResultCode(it)) }
+        ?: "unknown error"
+    )
+}
+fun ResultCode.errorString() = SqliteApi.errorString(this)
 
 interface ObjRef {
     fun dispose()
@@ -81,27 +49,6 @@ expect class DbRef : ObjRef
 
 expect class StmtRef : ObjRef {
     val dbRef: DbRef
-}
-
-class AuthorizationParams(
-    val actionCode: Int,
-    val param1: String?,
-    val param2: String?,
-    val param3: String?,
-    val param4: String?
-) {
-    override fun toString(): String {
-        return "AuthorizationParams(actionCode=$actionCode, param1=$param1, param2=$param2, param3=$param3, " +
-            "param4=$param4)"
-    }
-}
-
-// TODO make this a fun interface when migration to kotlin 1.4 happens
-//  maybe not as this likely needs a dispose :/
-interface Authorizer {
-    operator fun invoke(params: AuthorizationParams): AuthResult
-    fun dispose() {
-    }
 }
 
 /**

--- a/sqlitebindings/src/commonTest/kotlin/com/birbit/sqlite3/internal/AuthorizerTest.kt
+++ b/sqlitebindings/src/commonTest/kotlin/com/birbit/sqlite3/internal/AuthorizerTest.kt
@@ -15,6 +15,9 @@
  */
 package com.birbit.sqlite3.internal
 
+import com.birbit.sqlite3.AuthResult
+import com.birbit.sqlite3.AuthorizationParams
+import com.birbit.sqlite3.Authorizer
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/sqlitebindings/src/jvmMain/kotlin/com/birbit/sqlite3/internal/JvmSqliteApi.kt
+++ b/sqlitebindings/src/jvmMain/kotlin/com/birbit/sqlite3/internal/JvmSqliteApi.kt
@@ -15,6 +15,9 @@
  */
 package com.birbit.sqlite3.internal
 
+import com.birbit.sqlite3.Authorizer
+import com.birbit.sqlite3.ColumnType
+import com.birbit.sqlite3.ResultCode
 import org.scijava.nativelib.NativeLoader
 
 open class JvmObjRef(

--- a/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/GeneratedJni.kt
+++ b/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/GeneratedJni.kt
@@ -26,6 +26,8 @@ import com.birbit.jni.jint
 import com.birbit.jni.jlong
 import com.birbit.jni.jobject
 import com.birbit.jni.jstring
+import com.birbit.sqlite3.ColumnType
+import com.birbit.sqlite3.ResultCode
 import kotlin.Suppress
 import kotlin.native.CName
 import kotlinx.cinterop.CPointer

--- a/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/GeneratedJniUtils.kt
+++ b/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/GeneratedJniUtils.kt
@@ -23,6 +23,8 @@ import com.birbit.jni.jboolean
 import com.birbit.jni.jbyteArray
 import com.birbit.jni.jobject
 import com.birbit.jni.jstring
+import com.birbit.sqlite3.Authorizer
+import com.birbit.sqlite3.SqliteException
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.cstr

--- a/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/JniEnv.kt
+++ b/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/JniEnv.kt
@@ -24,6 +24,10 @@ import com.birbit.jni.jint
 import com.birbit.jni.jmethodID
 import com.birbit.jni.jobject
 import com.birbit.jni.jstring
+import com.birbit.sqlite3.AuthResult
+import com.birbit.sqlite3.AuthorizationParams
+import com.birbit.sqlite3.Authorizer
+import com.birbit.sqlite3.SqliteException
 import kotlin.native.concurrent.AtomicReference
 import kotlin.native.concurrent.freeze
 import kotlinx.cinterop.CFunction
@@ -139,14 +143,14 @@ internal class JvmAuthorizerCallback private constructor(
 
         override fun init(scope: MemScope, env: CPointer<JNIEnvVar>) {
             scope.run {
-                val classRef = obtainGlobalReference(env, "com/birbit/sqlite3/internal/Authorizer")
+                val classRef = obtainGlobalReference(env, "com/birbit/sqlite3/Authorizer")
                 val jvmAuthCallback = JvmAuthorizerCallback(
                     classRef = classRef,
                     invokeMethodId = getMethodId(
                         env,
                         classRef.jobject,
                         "invoke",
-                        "(Lcom/birbit/sqlite3/internal/AuthorizationParams;)I"
+                        "(Lcom/birbit/sqlite3/AuthorizationParams;)I"
                     ),
                     disposeMethodId = getMethodId(
                         env,
@@ -222,7 +226,7 @@ internal class JvmAuthorizerParams private constructor(
 
         override fun init(scope: MemScope, env: CPointer<JNIEnvVar>) {
             scope.run {
-                val classRef = obtainGlobalReference(env, "com/birbit/sqlite3/internal/AuthorizationParams")
+                val classRef = obtainGlobalReference(env, "com/birbit/sqlite3/AuthorizationParams")
                 val jvmAuthorizerParams = JvmAuthorizerParams(
                     classRef = classRef,
                     initMethodId = getMethodId(
@@ -262,7 +266,7 @@ internal class JvmSqliteException private constructor(
         val _instance = DisposableAtomicRef<JvmSqliteException>()
         override fun init(scope: MemScope, env: CPointer<JNIEnvVar>) {
             val jvmSqliteException = scope.run {
-                val classRef = obtainGlobalReference(env, "com/birbit/sqlite3/internal/SqliteException")
+                val classRef = obtainGlobalReference(env, "com/birbit/sqlite3/SqliteException")
                 JvmSqliteException(
                     classRef = classRef,
                     initMethodId = getMethodId(env, classRef.jobject, "<init>", "(ILjava/lang/String;)V")

--- a/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/SqliteApi.kt
+++ b/sqlitebindings/src/nativeMain/com/birbit/sqlite3/internal/SqliteApi.kt
@@ -18,6 +18,11 @@ package com.birbit.sqlite3.internal
 import cnames.structs.sqlite3
 import cnames.structs.sqlite3_stmt
 import com.birbit.jni.jlong
+import com.birbit.sqlite3.AuthorizationParams
+import com.birbit.sqlite3.Authorizer
+import com.birbit.sqlite3.ColumnType
+import com.birbit.sqlite3.ResultCode
+import com.birbit.sqlite3.SqliteException
 import kotlin.native.concurrent.AtomicReference
 import kotlin.native.concurrent.freeze
 import kotlinx.cinterop.ByteVar


### PR DESCRIPTION
This allows ksqlite to declare an api dependency on some parts of
sqlite bindings (e.g. ResultCode) while keeping direct sqlite
interactions internal