### PR TITLE
allow multi threaded access to db and stmt

### DIFF
--- a/ksqlite3/src/androidTest/kotlin/com/birbit/sqlite3/PlatformTestUtils.kt
+++ b/ksqlite3/src/androidTest/kotlin/com/birbit/sqlite3/PlatformTestUtils.kt
@@ -19,6 +19,8 @@ import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 
 actual object PlatformTestUtils {
     private val context: Context
@@ -41,5 +43,13 @@ actual object PlatformTestUtils {
 
     actual fun deleteDir(tmpDir: String) {
         File(tmpDir).deleteRecursively()
+    }
+
+    actual fun <T> runInAnotherThread(block: () -> T): T {
+        val result = AtomicReference<T>()
+        thread {
+            result.set(block())
+        }.join()
+        return result.get()
     }
 }

--- a/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/PlatformTestUtils.kt
+++ b/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/PlatformTestUtils.kt
@@ -20,6 +20,7 @@ expect object PlatformTestUtils {
     fun fileExists(path: String): Boolean
     fun fileSeparator(): Char
     fun deleteDir(tmpDir: String)
+    fun <T> runInAnotherThread(block: () -> T): T
 }
 
 fun <T> withTmpFolder(block: TmpFolderScope.() -> T) {

--- a/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/StatementTest.kt
+++ b/ksqlite3/src/commonTest/kotlin/com/birbit/sqlite3/StatementTest.kt
@@ -15,6 +15,7 @@
  */
 package com.birbit.sqlite3
 
+import com.birbit.sqlite3.PlatformTestUtils.runInAnotherThread
 import com.birbit.sqlite3.SqliteStmt.BindParameterMetadata
 import com.birbit.sqlite3.SqliteStmt.BindParameterMetadata.BindParameter
 import com.birbit.sqlite3.SqliteStmt.ResultMetadata
@@ -346,6 +347,21 @@ class StatementTest {
                 }.toList()
             }
             assertEquals(results, listOf("x", "y"))
+        }
+    }
+
+    @Test
+    fun multiThreadedAccess() {
+        SqliteConnection.openConnection(":memory:").use { conn ->
+            conn.exec("CREATE TABLE Foo(text TEXT)")
+            conn.exec("INSERT INTO Foo VALUES('bar')")
+            val stmt = conn.prepareStmt("SELECT * FROM Foo")
+            val result = runInAnotherThread {
+                stmt.use {
+                    it.query().first().readString(0)
+                }
+            }
+            assertEquals("bar", result)
         }
     }
 

--- a/ksqlite3/src/jvmTest/kotlin/com/birbit/sqlite3/PlatformTestUtils.kt
+++ b/ksqlite3/src/jvmTest/kotlin/com/birbit/sqlite3/PlatformTestUtils.kt
@@ -18,6 +18,8 @@ package com.birbit.sqlite3
 import java.io.File
 import java.nio.file.Paths
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 
 actual object PlatformTestUtils {
     actual fun getTmpDir(): String {
@@ -40,5 +42,13 @@ actual object PlatformTestUtils {
         val file = File(tmpDir)
         if (!file.exists()) return
         file.deleteRecursively()
+    }
+
+    actual fun <T> runInAnotherThread(block: () -> T): T {
+        val result = AtomicReference<T>()
+        thread {
+            result.set(block())
+        }.join()
+        return result.get()
     }
 }

--- a/sqlitebindings/src/nativeMain/kotlin/com/birbit/sqlite3/internal/SqliteApi.kt
+++ b/sqlitebindings/src/nativeMain/kotlin/com/birbit/sqlite3/internal/SqliteApi.kt
@@ -109,6 +109,9 @@ internal class NativeRef<T : Any>(target: T) : ObjRef {
 
 actual class StmtRef(@Suppress("unused") actual val dbRef: DbRef, val rawPtr: CPointer<sqlite3_stmt>) : ObjRef {
     private val nativeRef = NativeRef(this)
+    init {
+        freeze()
+    }
     fun toJni() = nativeRef.stableRef.toJni()
 
     companion object {
@@ -126,6 +129,9 @@ actual class StmtRef(@Suppress("unused") actual val dbRef: DbRef, val rawPtr: CP
 actual class DbRef(val rawPtr: CPointer<sqlite3>) : ObjRef {
     private val nativeRef = NativeRef(this)
     internal val authorizer = AtomicReference<NativeRef<Authorizer>?>(null)
+    init {
+        freeze()
+    }
     fun toJni() = nativeRef.stableRef.toJni()
 
     companion object {


### PR DESCRIPTION
These objects are just references to their C pointers, thus
can be frozen safely. Multithreading on the SQLite is more
complicated and we might handle it once ksqlite3 has multi
threaded APIs but for now, it is best the core to allow
multi-threaded access and let upper layers manage it.